### PR TITLE
feat: setup initial Axios instance with basic interceptore

### DIFF
--- a/src/services/axiosClient.js
+++ b/src/services/axiosClient.js
@@ -1,0 +1,38 @@
+import axios from "axios";
+import { config } from "flowbite-react/plugin/tailwindcss/config";
+
+const axiosClient = axios.create({
+
+    baseURL: "http://localhost:3000/api/",
+    headers: {
+        "Content-type": "application/json",
+    },
+});
+
+//Request Interceptor
+axiosClient.interceptors.request.use(
+    (config) => {
+        const token = localStorage.getItem("token");
+        
+        if (token) {
+            config.headers.Authorization = `Bearer ${token}`;
+        }
+        return config;
+    },
+    (error) => Promise.reject(error)
+    
+);
+
+//Response Interceptor
+axiosClient.interceptors.response.use(
+    (response) => response,
+    (error) => {
+        if(error.response && error.response.status === 401) {
+            localStorage.removeItem("token");
+            window.location.href = "/login";
+        }
+        return Promise.reject(error)
+    }
+);
+
+export default axiosClient;


### PR DESCRIPTION
This PR adds the initial setup for the Axios instance, including the base configuration and request/response interceptors.

The current implementation focuses on establishing the core structure for handling API requests.

The authentication flow (login, signup, token handling, logout) and the global loader will be added in upcoming updates. After completing these features, I will refine the Axios logic as needed.
